### PR TITLE
simplify usage, readonly copy instead of view

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ For motivation and details see the https://m-m-m.github.io/docs/api/io.github.mm
 
 [source,java]
 -----
-public class TestBean extends Bean {
+public class TestBean extends DynamicBean {
 
   /** Full name of person. */
   public final StringProperty Name;
@@ -25,15 +25,9 @@ public class TestBean extends Bean {
   public final IntegerProperty Age;
 
   public TestBean() {
-
-    this(null, true);
-  }
-
-  public TestBean(AbstractBean writable, boolean dynamic) {
-
-    super(writable, dynamic);
-    this.Name = add(new StringProperty("Name"));
-    this.Age = add(new IntegerProperty("Age"));
+    // this.Name = add(new StringProperty("Name"));
+    this.Name = add().newString("Name");
+    this.Age = add().newInteger("Age");
   }
 }
 -----
@@ -42,7 +36,6 @@ Wait, that looks kind of odd, right?
 
 * Capitalized field names - that is a violation of Java conventions. C# hackers doing Java coding, or what?
 * So public fields - ain't that an anti-pattern?
-* And what are those strange contructor arguments?
 * Do you guys have to reinvent Java fundamentals?
 
 Before we answer these questions lets first have a look at the usage:
@@ -52,13 +45,14 @@ Before we answer these questions lets first have a look at the usage:
 TestBean bean = new TestBean();
 bean.Name.set("John Doe");
 bean.Age.set(42);
-// Read-Only views
-TestBean readonly = WritableBean.getReadOnly(bean);
+// Read-Only copy
+TestBean readonly = ReadableBean.copyReadOnly(bean);
 assertThat(readonly.Age.get()).isEqualTo(42);
 bean.Age.set(43);
-assertThat(readonly.Age.get()).isEqualTo(43);
+assertThat(bean.Age.get()).isEqualTo(43);
+assertThat(readonly.Age.get()).isEqualTo(42);
 try {
-  readonly.Age.set(44);
+  readonly.Age.set(43);
   fail("Exception expected");
 } catch (IllegalStateException e) {
 }
@@ -70,19 +64,22 @@ TestBean bean2 = new TestBean();
 for (WritableProperty<?> property : bean.getProperties()) {
   bean2.set(property.getName(), property.getValue());
 }
+// default equals and hashCode from Object for fast usage in collections
+assertThat(bean).isNotEqualTo(bean2); 
+// build in support for sematical equals comparing by value
 assertThat(bean.isEqualTo(bean2)).isTrue();
 -----
 
 This is just the beginning. There is so much more:
 
 * build-in JSON and XML mapping
-* polymorphic type hierarchies
 * powerful validation support
-* all ready as modules for Java11
+* all ready as modules for Java11+
 * generic metadata and annotations on properties
 * unidircational and bidirectional bindings
 * computational expressions for property values
 * dynamic property support
+* polymorphic type hierarchies
 * optional virtual run-time type creation with protoypic inheritance
 * alternative support for bean interfaces as dynamic proxies providing multi-inheritance and even less boiler-plate code (but more magic and overhead)
 * ...
@@ -97,8 +94,6 @@ However, this again is pointless boiler-plate code and our intention is to make 
 Instead, ask yourself, why getters and setters have been introduced once?
 All these reasons do not apply for properties declared as public final (!) fields.
 You can even change your code to make them readonly, computed, etc.
-* The argumented constructor is needed to create read-only views of the bean.
-In case you do not need such features, you can ommit such constructor.
 * And yes, classic Java Beans aka POJOs suck.
 Everybody hates them.
 You may also use https://projectlombok.org/[Lombok] instead.
@@ -130,7 +125,7 @@ Well, for JavaScript clients no problem. But for Java clients your entity class 
 It will either already fail to load the entity or lose the property value when sending the changes back for saving.
 
 So wouldn't it be nice to have a way to support something like this in Java as well?
-The beans we offer here support exactly what you need for this problem. Simply create them as dynamic beans (provide `true` for the dynamic flag in super constructor).
+The beans we offer here support exactly what you need for this problem. Simply extends your beans from `DynamicBean` instead of `Bean` or override the `isDynamic` method.
 
 [source,java]
 -----
@@ -141,10 +136,7 @@ bean.Age.set(16);
 WritableProperty<Instant> foo = bean.getOrCreateProperty("Foo", Instant.class);
 foo.setValue(Instant.parse("1999-12-31T23:59:59Z"));
 // Write JSON
-StringWriter stringWriter = new StringWriter();
-StructuredWriter writer = JsonpMarshalling.of().writer(stringWriter);
-bean.write(writer);
-String json = stringWriter.toString();
+String json = JsonMarshalling.of().write(bean);
 System.out.println(json);
 -----
 
@@ -160,4 +152,4 @@ This will print the following JSON:
 -----
 
 So if you want the best of both worlds (static and dynamic typing), you have found the solution now.
-Of course you can populate an existing bean with data from JSON in an analog way.
+Of course you can populate an existing bean with data from JSON in an analog way and of course there is full stream support for `Reader` and `Writer`.

--- a/core/src/main/java/io/github/mmm/bean/AbstractVirtualBean.java
+++ b/core/src/main/java/io/github/mmm/bean/AbstractVirtualBean.java
@@ -15,58 +15,36 @@ public abstract class AbstractVirtualBean extends AbstractBean implements Virtua
 
   private static final AtomicLong MODIFICATION_SEQUNCE = new AtomicLong(1);
 
-  private final BeanClassImpl type;
-
   private long modificationCounter;
 
   private long updateCounter;
+
+  private /* final */ BeanClassImpl type;
 
   /**
    * The constructor.
    */
   public AbstractVirtualBean() {
 
-    this(null, false);
+    this(null);
   }
 
   /**
    * The constructor.
    *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public AbstractVirtualBean(AbstractBean writable, boolean dynamic) {
-
-    this(writable, dynamic, null);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
    * @param type the {@link #getType() type}.
    */
-  public AbstractVirtualBean(AbstractBean writable, boolean dynamic, BeanClass type) {
+  public AbstractVirtualBean(BeanClass type) {
 
-    super(writable, dynamic);
-    Class<? extends AbstractVirtualBean> javaClass = getClass();
+    super();
     if (type == null) {
-      if (writable != null) {
-        this.type = ((AbstractVirtualBean) writable).type.getReadOnly();
-      } else {
-        this.type = BeanClassImpl.asClass(javaClass);
-        if (this.type.getPrototype() == null) {
-          this.type.setPrototype(this);
-        }
-      }
+      Class<? extends AbstractVirtualBean> javaClass = getClass();
+      this.type = BeanClassImpl.asClass(javaClass);
     } else {
       this.type = (BeanClassImpl) type;
-      if (this.type.getPrototype() == null) {
-        this.type.setPrototype(this);
-      }
+    }
+    if (this.type.getPrototype() == null) {
+      this.type.setPrototype(this);
     }
   }
 
@@ -89,6 +67,35 @@ public abstract class AbstractVirtualBean extends AbstractBean implements Virtua
   }
 
   @Override
+  protected AbstractBean create() {
+
+    AbstractVirtualBean bean = (AbstractVirtualBean) super.create();
+    bean.type = this.type;
+    return bean;
+  }
+
+  @Override
+  public WritableProperty<?> getProperty(String name) {
+
+    updateProperties();
+    return super.getProperty(name);
+  }
+
+  @Override
+  public int getPropertyCount() {
+
+    updateProperties();
+    return super.getPropertyCount();
+  }
+
+  @Override
+  public Iterable<? extends WritableProperty<?>> getProperties() {
+
+    updateProperties();
+    return super.getProperties();
+  }
+
+  @Override
   protected void onPropertyAdded(WritableProperty<?> property) {
 
     super.onPropertyAdded(property);
@@ -97,10 +104,12 @@ public abstract class AbstractVirtualBean extends AbstractBean implements Virtua
     }
   }
 
-  @Override
+  /**
+   * Called before properties are accessed if {@link #isDynamic() dynamic} and not {@link #isReadOnly() read-only} to
+   * allow implementations to update properties internally before.
+   */
   protected void updateProperties() {
 
-    super.updateProperties();
     if (isPrototype()) {
       long maxCounter = this.updateCounter;
       for (BeanClass superClass : this.type.getSuperClasses()) {

--- a/core/src/main/java/io/github/mmm/bean/AbstractVirtualBean.java
+++ b/core/src/main/java/io/github/mmm/bean/AbstractVirtualBean.java
@@ -49,6 +49,12 @@ public abstract class AbstractVirtualBean extends AbstractBean implements Virtua
   }
 
   @Override
+  public boolean isDynamic() {
+
+    return true;
+  }
+
+  @Override
   protected boolean isThreadSafe() {
 
     return isDynamic();

--- a/core/src/main/java/io/github/mmm/bean/AdvancedBean.java
+++ b/core/src/main/java/io/github/mmm/bean/AdvancedBean.java
@@ -22,26 +22,11 @@ public class AdvancedBean extends AbstractVirtualBean {
   /**
    * The constructor.
    *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public AdvancedBean(AbstractBean writable, boolean dynamic) {
-
-    super(writable, dynamic);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
    * @param type the {@link #getType() type}.
    */
-  public AdvancedBean(AbstractBean writable, boolean dynamic, BeanClass type) {
+  public AdvancedBean(BeanClass type) {
 
-    super(writable, dynamic, type);
+    super(type);
     Class<? extends AdvancedBean> javaClass = getClass();
     if ((type != null) && (type.getJavaClass() != javaClass)) {
       throw new IllegalArgumentException(

--- a/core/src/main/java/io/github/mmm/bean/Bean.java
+++ b/core/src/main/java/io/github/mmm/bean/Bean.java
@@ -16,19 +16,7 @@ public class Bean extends AbstractBean {
    */
   public Bean() {
 
-    this(null, false);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public Bean(AbstractBean writable, boolean dynamic) {
-
-    super(writable, dynamic);
+    super();
     this.type = BeanTypeImpl.asType(getClass());
   }
 

--- a/core/src/main/java/io/github/mmm/bean/BeanClass.java
+++ b/core/src/main/java/io/github/mmm/bean/BeanClass.java
@@ -108,7 +108,7 @@ public interface BeanClass extends BeanType {
    * @param stableName the {@link #getStableName() stable name}.
    * @param superClasses the {@link #getSuperClasses() super-classes}.
    * @return the created {@link #isVirtual() virtual} {@link BeanClass}.
-   * @see AdvancedBean#AdvancedBean(AbstractBean, boolean, BeanClass)
+   * @see AdvancedBean#AdvancedBean(BeanClass)
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   static BeanClass createVirtual(String packageName, String simpleName, String stableName, BeanClass... superClasses) {

--- a/core/src/main/java/io/github/mmm/bean/DynamicBean.java
+++ b/core/src/main/java/io/github/mmm/bean/DynamicBean.java
@@ -6,25 +6,20 @@ package io.github.mmm.bean;
  * A {@link Bean} that is always {@link #isDynamic() dynamic}. Only exists for simplicity.
  */
 @Name("mmm.DynamicBean")
-public final class DynamicBean extends Bean {
+public class DynamicBean extends Bean {
 
   /**
    * The constructor.
    */
   public DynamicBean() {
 
-    super(null, true);
-  }
-
-  private DynamicBean(AbstractBean writable) {
-
-    super(writable, true);
+    super();
   }
 
   @Override
-  protected Bean create(AbstractBean writableBean, boolean dynamic) {
+  public boolean isDynamic() {
 
-    return new DynamicBean(writableBean);
+    return true;
   }
 
 }

--- a/core/src/main/java/io/github/mmm/bean/PropertyBuilders.java
+++ b/core/src/main/java/io/github/mmm/bean/PropertyBuilders.java
@@ -2,19 +2,25 @@
  * http://www.apache.org/licenses/LICENSE-2.0 */
 package io.github.mmm.bean;
 
+import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.github.mmm.bean.AbstractBean.AddMode;
+import io.github.mmm.bean.impl.BeanPropertyMetadataFactory;
+import io.github.mmm.property.PropertyMetadata;
+import io.github.mmm.property.PropertyMetadataFactory;
 import io.github.mmm.property.WritableProperty;
 import io.github.mmm.property.builder.DefaultPropertyBuilders;
+import io.github.mmm.validation.Validator;
 
 /**
  * Implementation of {@link DefaultPropertyBuilders} that auto registers build properties and redirects to read-only
  * properties if {@link AbstractBean#isReadOnly() read-only}.
  */
 public class PropertyBuilders
-    implements DefaultPropertyBuilders, Consumer<WritableProperty<?>>, Function<String, WritableProperty<?>> {
+    implements DefaultPropertyBuilders, Consumer<WritableProperty<?>>, PropertyMetadataFactory {
 
   private final AbstractBean bean;
 
@@ -29,17 +35,15 @@ public class PropertyBuilders
   }
 
   @Override
-  public WritableProperty<?> apply(String name) {
-
-    if (this.bean.writable != null) {
-      return this.bean.writable.getProperty(name).getReadOnly();
-    }
-    return null;
-  }
-
-  @Override
   public void accept(WritableProperty<?> property) {
 
     this.bean.add(property, AddMode.DIRECT);
+  }
+
+  @Override
+  public <V> PropertyMetadata<V> create(Validator<? super V> validator, Supplier<? extends V> expression,
+      Type valueType, Map<String, Object> map) {
+
+    return BeanPropertyMetadataFactory.get().create(validator, expression, valueType, map);
   }
 }

--- a/core/src/main/java/io/github/mmm/bean/ReadableBean.java
+++ b/core/src/main/java/io/github/mmm/bean/ReadableBean.java
@@ -22,8 +22,8 @@ import io.github.mmm.validation.ValidationResultBuilder;
  * read data from Database, XML, or JSON you can still map "undefined" properties in your {@link Bean}. This way a
  * client can receive an object from a newer version of a database or service with added properties that will be kept in
  * the object and send back when the {@link Bean} is written back.</li>
- * <li><b>ReadOnly-Support</b> - {@link WritableBean#getReadOnly(WritableBean) create} a {@link #isReadOnly() read-only}
- * view of your object to pass by reference without side-effects.</li>
+ * <li><b>ReadOnly-Support</b> - create a {@link #isReadOnly() read-only} {@link #copy(boolean) copy} of your object to
+ * pass by reference without side-effects.</li>
  * <li><b>Powerful</b> - {@link WritableProperty} supports listeners and bindings as well as
  * {@link WritableProperty#getValueClass() generic type information}.</li>
  * <li><b>Validation</b> - build-in {@link #validate() validation support}.</li>
@@ -117,7 +117,6 @@ public interface ReadableBean extends Validatable, MarshallableObject {
 
   /**
    * @return {@code true} if this {@link Bean} is read-only (immutable), {@code false} otherwise.
-   * @see WritableBean#getReadOnly(WritableBean)
    */
   boolean isReadOnly();
 
@@ -210,6 +209,66 @@ public interface ReadableBean extends Validatable, MarshallableObject {
       }
     }
     writer.writeEnd();
+  }
+
+  /**
+   * @return a copy of this {@link WritableBean}. Like {@link #newInstance()} but with the values copied into the new
+   *         instance.
+   */
+  default WritableBean copy() {
+
+    return copy(false);
+  }
+
+  /**
+   * @param readOnly - {@code true} if the copy shall be {@link #isReadOnly() read-only}.
+   * @return a {@link #copy() copy} of this {@link WritableBean}. If {@code readOnly} is {@code true} and this bean is
+   *         already {@link #isReadOnly() read-only}, the same instance will be returned.
+   */
+  WritableBean copy(boolean readOnly);
+
+  /**
+   * @return a new instance of this {@link WritableBean}.
+   */
+  WritableBean newInstance();
+
+  /**
+   * @param <B> type of the {@link WritableBean}.
+   * @param bean the {@link WritableBean} to create a {@link #newInstance() new instance} of.
+   * @return the {@link #newInstance() new instance}.
+   */
+  @SuppressWarnings("unchecked")
+  static <B extends ReadableBean> B newInstance(B bean) {
+
+    if (bean == null) {
+      return null;
+    }
+    return (B) bean.newInstance();
+  }
+
+  /**
+   * @param <B> type of the {@link WritableBean}.
+   * @param bean the {@link WritableBean} to {@link #copy(boolean) copy}.
+   * @param readOnly - {@code true} if the copy shall be {@link #isReadOnly() read-only}.
+   * @return the {@link #copy(boolean) copy}.
+   */
+  @SuppressWarnings("unchecked")
+  static <B extends ReadableBean> B copy(B bean, boolean readOnly) {
+
+    if (bean == null) {
+      return null;
+    }
+    return (B) bean.copy(readOnly);
+  }
+
+  /**
+   * @param <B> type of the {@link WritableBean}.
+   * @param bean the {@link WritableBean} to {@link #copy(boolean) copy}.
+   * @return the {@link #isReadOnly() read-only} {@link #copy(boolean) copy}.
+   */
+  static <B extends ReadableBean> B copyReadOnly(B bean) {
+
+    return copy(bean, true);
   }
 
 }

--- a/core/src/main/java/io/github/mmm/bean/WritableBean.java
+++ b/core/src/main/java/io/github/mmm/bean/WritableBean.java
@@ -198,48 +198,4 @@ public interface WritableBean extends ReadableBean, MarshallingObject {
     }
   }
 
-  /**
-   * @return a new instance of this {@link WritableBean}.
-   */
-  WritableBean newInstance();
-
-  /**
-   * @return a {@link #isReadOnly() immutable} view of this {@link WritableBean}. Read operations on this
-   *         {@link #isReadOnly() immutable} view will produce the exact same results as on the original
-   *         {@link WritableBean}. However, all write operations will fail.
-   * @see #getReadOnly(WritableBean)
-   */
-  WritableBean getReadOnly();
-
-  /**
-   * @param <B> type of the {@link WritableBean}.
-   * @param bean the {@link WritableBean} to get a {@link #getReadOnly() read-only view} for.
-   * @return the {@link #getReadOnly() read-only view}.
-   */
-  @SuppressWarnings("unchecked")
-  static <B extends WritableBean> B getReadOnly(B bean) {
-
-    if (bean == null) {
-      return null;
-    } else if (bean.isReadOnly()) {
-      return bean;
-    } else {
-      return (B) bean.getReadOnly();
-    }
-  }
-
-  /**
-   * @param <B> type of the {@link WritableBean}.
-   * @param bean the {@link WritableBean} to create a new instance of.
-   * @return the {@link #newInstance() new instance}.
-   */
-  @SuppressWarnings("unchecked")
-  static <B extends WritableBean> B newInstance(B bean) {
-
-    if (bean == null) {
-      return null;
-    }
-    return (B) bean.newInstance();
-  }
-
 }

--- a/core/src/main/java/io/github/mmm/bean/impl/BeanClassImpl.java
+++ b/core/src/main/java/io/github/mmm/bean/impl/BeanClassImpl.java
@@ -38,8 +38,6 @@ public final class BeanClassImpl extends BeanTypeImpl implements BeanClass {
 
   private VirtualBean prototype;
 
-  private BeanClassImpl readOnly;
-
   static {
     asClass(VirtualBean.class);
   }
@@ -134,20 +132,6 @@ public final class BeanClassImpl extends BeanTypeImpl implements BeanClass {
     this.virtual = virtual;
   }
 
-  private BeanClassImpl(BeanClassImpl writable) {
-
-    super(writable);
-    this.superClassList = writable.superClassList;
-    this.superClasses = writable.superClasses;
-    this.packageName = writable.packageName;
-    this.simpleName = writable.simpleName;
-    this.qualifiedName = writable.qualifiedName;
-    this.virtual = writable.virtual;
-    // TODO
-    this.prototype = writable.getPrototype();
-    this.readOnly = this;
-  }
-
   @SuppressWarnings("unchecked")
   @Override
   public Class<? extends VirtualBean> getJavaClass() {
@@ -207,17 +191,6 @@ public final class BeanClassImpl extends BeanTypeImpl implements BeanClass {
     }
     Objects.requireNonNull(prototype, "prototype");
     this.prototype = prototype;
-  }
-
-  /**
-   * @return the read-only view of this bean-class.
-   */
-  public BeanClassImpl getReadOnly() {
-
-    if (this.readOnly == null) {
-      this.readOnly = new BeanClassImpl(this);
-    }
-    return this.readOnly;
   }
 
   /**

--- a/core/src/main/java/io/github/mmm/bean/impl/BeanClassImpl.java
+++ b/core/src/main/java/io/github/mmm/bean/impl/BeanClassImpl.java
@@ -14,7 +14,6 @@ import io.github.mmm.bean.AdvancedBean;
 import io.github.mmm.bean.Bean;
 import io.github.mmm.bean.BeanClass;
 import io.github.mmm.bean.VirtualBean;
-import io.github.mmm.bean.WritableBean;
 
 /**
  * A {@link BeanClass} reflects a {@link Bean} (similar to a Java {@link Class}).
@@ -144,7 +143,8 @@ public final class BeanClassImpl extends BeanTypeImpl implements BeanClass {
     this.simpleName = writable.simpleName;
     this.qualifiedName = writable.qualifiedName;
     this.virtual = writable.virtual;
-    this.prototype = WritableBean.getReadOnly(writable.prototype);
+    // TODO
+    this.prototype = writable.getPrototype();
     this.readOnly = this;
   }
 

--- a/core/src/main/java/io/github/mmm/bean/impl/BeanCreator.java
+++ b/core/src/main/java/io/github/mmm/bean/impl/BeanCreator.java
@@ -12,11 +12,9 @@ import io.github.mmm.bean.WritableBean;
  * Creator of {@link AbstractBean} instances.
  *
  * @since 1.0.0
- * @see #create(Class, AbstractBean, boolean)
+ * @see #doCreate(Class)
  */
 public final class BeanCreator implements BeanFactory {
-
-  private static final Class<?>[] CONSTRUCTOR_SIGNATURE = new Class<?>[] { AbstractBean.class, boolean.class };
 
   /**
    * The constructor.
@@ -34,7 +32,7 @@ public final class BeanCreator implements BeanFactory {
       if (type.isInterface()) {
         return null;
       }
-      return (B) create((Class) type, null, dynamic);
+      return (B) doCreate((Class) type);
     } catch (Exception e) {
       throw new IllegalStateException(e.getMessage(), e);
     }
@@ -43,17 +41,14 @@ public final class BeanCreator implements BeanFactory {
   /**
    * @param <B> type of {@link AbstractBean}.
    * @param type {@link Class} of {@link AbstractBean}.
-   * @param writableBean the {@link AbstractBean} to create a {@link AbstractBean#getReadOnly() read-only} copy of.
-   * @param dynamicFlag the {@link AbstractBean#isDynamic() dynamic flag}.
    * @return the new bean instance.
    * @throws ReflectiveOperationException in case of an error.
    */
   @SuppressWarnings("unchecked")
-  public static <B extends AbstractBean> B create(Class<B> type, AbstractBean writableBean, boolean dynamicFlag)
-      throws ReflectiveOperationException {
+  public static <B extends AbstractBean> B doCreate(Class<B> type) throws ReflectiveOperationException {
 
-    Constructor<? extends AbstractBean> constructor = type.getConstructor(CONSTRUCTOR_SIGNATURE);
-    return (B) constructor.newInstance(writableBean, Boolean.valueOf(dynamicFlag));
+    Constructor<? extends AbstractBean> constructor = type.getConstructor();
+    return (B) constructor.newInstance();
   }
 
 }

--- a/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadata.java
+++ b/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadata.java
@@ -1,0 +1,20 @@
+/* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0 */
+package io.github.mmm.bean.impl;
+
+import io.github.mmm.property.PropertyMetadata;
+
+/**
+ * {@link PropertyMetadata} for a {@link io.github.mmm.bean.AbstractBean}.
+ *
+ * @param <V> type of the {@link io.github.mmm.property.Property#get() property value}.
+ * @since 1.0.0
+ */
+public interface BeanPropertyMetadata<V> extends PropertyMetadata<V> {
+
+  /**
+   * @param value the fixed value to set as {@link #getExpression() expression} to make the property read-only.
+   */
+  void makeReadOnly(V value);
+
+}

--- a/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadataFactory.java
+++ b/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadataFactory.java
@@ -1,0 +1,40 @@
+/* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0 */
+package io.github.mmm.bean.impl;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.github.mmm.property.PropertyMetadata;
+import io.github.mmm.property.PropertyMetadataFactory;
+import io.github.mmm.validation.Validator;
+
+/**
+ * Implementation of {@link PropertyMetadataFactory} for {@link BeanPropertyMetadata}.
+ *
+ * @since 1.0.0
+ */
+public class BeanPropertyMetadataFactory implements PropertyMetadataFactory {
+
+  private static final BeanPropertyMetadataFactory INSTANCE = new BeanPropertyMetadataFactory();
+
+  @Override
+  public <V> PropertyMetadata<V> create(Validator<? super V> validator, Supplier<? extends V> expression,
+      Type valueType, Map<String, Object> map) {
+
+    if (Validator.isValidating(validator) || (expression != null) || (valueType != null) || (map != null)) {
+      return new BeanPropertyMetadataType<>(validator, expression, valueType, map);
+    }
+    return new BeanPropertyMetadataSimple<>();
+  }
+
+  /**
+   * @return the singleton instance of this {@link BeanPropertyMetadataFactory}.
+   */
+  public static BeanPropertyMetadataFactory get() {
+
+    return INSTANCE;
+  }
+
+}

--- a/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadataSimple.java
+++ b/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadataSimple.java
@@ -1,0 +1,47 @@
+/* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0 */
+package io.github.mmm.bean.impl;
+
+import java.util.function.Supplier;
+
+import io.github.mmm.property.AbstractPropertyMetadata;
+import io.github.mmm.property.PropertyMetadata;
+import io.github.mmm.property.PropertyMetadataType;
+import io.github.mmm.validation.Validator;
+
+/**
+ * Implementation of {@link BeanPropertyMetadata} extending {@link PropertyMetadataType}.
+ *
+ * @param <V> type of the {@link io.github.mmm.property.Property#get() property value}.
+ * @since 1.0.0
+ */
+public class BeanPropertyMetadataSimple<V> extends AbstractPropertyMetadata<V> implements BeanPropertyMetadata<V> {
+
+  private Supplier<V> expression;
+
+  @Override
+  public Supplier<? extends V> getExpression() {
+
+    return this.expression;
+  }
+
+  @Override
+  public void makeReadOnly(V value) {
+
+    if (this.expression != null) {
+      // should actually be called only once...
+      return;
+    }
+    this.expression = () -> value;
+  }
+
+  @Override
+  public PropertyMetadata<V> withValidator(Validator<? super V> validator) {
+
+    if (Validator.isValidating(validator)) {
+      return new BeanPropertyMetadataType<>(validator, this.expression);
+    }
+    return this;
+  }
+
+}

--- a/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadataType.java
+++ b/core/src/main/java/io/github/mmm/bean/impl/BeanPropertyMetadataType.java
@@ -1,0 +1,55 @@
+/* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0 */
+package io.github.mmm.bean.impl;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.github.mmm.property.PropertyMetadataType;
+import io.github.mmm.validation.Validator;
+
+/**
+ * Implementation of {@link BeanPropertyMetadata} extending {@link PropertyMetadataType}.
+ *
+ * @param <V> type of the {@link io.github.mmm.property.Property#get() property value}.
+ * @since 1.0.0
+ */
+public class BeanPropertyMetadataType<V> extends PropertyMetadataType<V> implements BeanPropertyMetadata<V> {
+
+  /**
+   * The constructor.
+   *
+   * @param validator the {@link #getValidator() validator}.
+   * @param expression the {@link #getExpression() expression}.
+   */
+  public BeanPropertyMetadataType(Validator<? super V> validator, Supplier<? extends V> expression) {
+
+    super(validator, expression, null, null);
+  }
+
+  /**
+   * The constructor.
+   *
+   * @param validator the {@link #getValidator() validator}.
+   * @param expression the {@link #getExpression() expression}.
+   * @param valueType the {@link #getValueType() value type}.
+   * @param metadata the {@link #get(String) metadata}.
+   */
+  public BeanPropertyMetadataType(Validator<? super V> validator, Supplier<? extends V> expression, Type valueType,
+      Map<String, Object> metadata) {
+
+    super(validator, expression, valueType, metadata);
+  }
+
+  @Override
+  public void makeReadOnly(V value) {
+
+    if (this.expression != null) {
+      // should actually be called only once...
+      return;
+    }
+    this.expression = () -> value;
+  }
+
+}

--- a/core/src/test/java/io/github/mmm/bean/AbstractBeanTest.java
+++ b/core/src/test/java/io/github/mmm/bean/AbstractBeanTest.java
@@ -54,22 +54,22 @@ public abstract class AbstractBeanTest extends Assertions {
     String propertyName = property.getName();
     assertThat(bean.getRequiredProperty(propertyName)).isSameAs(property);
     if (!bean.isReadOnly()) {
-      AbstractBean readOnlyBean = bean.getReadOnly();
+      WritableBean readOnlyBean = bean.copy(true);
       assertThat(readOnlyBean.isReadOnly()).isTrue();
       assertThat(readOnlyBean.getClass()).isSameAs(bean.getClass());
       WritableProperty<?> readOnlyProperty = readOnlyBean.getRequiredProperty(property.getName());
-      assertThat(readOnlyProperty).isNotSameAs(property).isEqualTo(property).isSameAs(property.getReadOnly());
+      assertThat(readOnlyProperty).isNotSameAs(property).isEqualTo(property);
       assertThat(readOnlyProperty.isReadOnly()).isTrue();
       assertThat(property.get()).isEqualTo(bean.get(property.getName()))
           .isEqualTo(readOnlyBean.get(property.getName()));
       if (newValue != null) {
         assertThat(property.get()).isNotEqualTo(newValue);
         ObservableEventReceiver<Object> listener = new ObservableEventReceiver<>();
-        readOnlyProperty.addListener(listener);
+        property.addListener(listener);
         property.set(newValue);
         assertThat(listener.getEventCount()).isEqualTo(1);
         assertThat(listener.getEvent().getValue()).isEqualTo(newValue);
-        readOnlyProperty.removeListener(listener);
+        property.removeListener(listener);
       }
     }
   }

--- a/core/src/test/java/io/github/mmm/bean/AdvancedBeanTest.java
+++ b/core/src/test/java/io/github/mmm/bean/AdvancedBeanTest.java
@@ -40,11 +40,12 @@ public class AdvancedBeanTest extends AbstractBeanTest {
     assertThat(testAdvancedParentBeanClass.getStableName()).isEqualTo("mmm.TestAdvancedParentBean");
 
     // bean
-    TestAdvancedBean prototype = new TestAdvancedBean(true, virtucalBeanClass);
+    // first instance created for virtual bean class is the prototype
+    TestAdvancedBean prototype = new TestAdvancedBean(virtucalBeanClass);
     assertThat(prototype.isPrototype()).isTrue();
     assertThat(prototype.getType()).isSameAs(virtucalBeanClass);
     assertThat(virtucalBeanClass.getPrototype()).isSameAs(prototype);
-    TestAdvancedBean bean = new TestAdvancedBean(true, virtucalBeanClass);
+    TestAdvancedBean bean = new TestAdvancedBean(virtucalBeanClass);
     assertThat(bean.isPrototype()).isFalse();
     assertThat(bean.isDynamic()).isTrue();
     assertThat(bean.isReadOnly()).isFalse();
@@ -59,38 +60,37 @@ public class AdvancedBeanTest extends AbstractBeanTest {
     assertThat(virtucalBeanClass.getPrototype().getPropertyCount()).isEqualTo(2);
     assertThat(BeanHelper.getPropertyNames(virtucalBeanClass.getPrototype())).containsExactlyInAnyOrder("Name", "Age");
     assertThat(testAdvancedBeanClass.getPrototype().getPropertyCount()).isEqualTo(2);
-    TestAdvancedBean readOnly = WritableBean.getReadOnly(bean);
+    String name = "John Doe";
+    bean.Name.set(name);
+    int age = 42;
+    bean.Age.set(age);
+    LocalDateProperty birthday = bean.addProperty(new LocalDateProperty("Birthday"));
+    assertThat(bean.getPropertyCount()).isEqualTo(3);
+    assertThat(bean.getProperty("Birthday")).isSameAs(birthday);
+    // yes, this is inconsistent and does not match the age, it is only a test
+    LocalDate date = LocalDate.of(2003, 02, 01);
+    birthday.set(date);
+    TestAdvancedBean readOnly = ReadableBean.copy(bean, true);
     assertThat(readOnly.getRequiredProperty("Name")).isSameAs(readOnly.Name).isNotSameAs(bean.Name)
         .isEqualTo(bean.Name);
     assertThat(readOnly.getRequiredProperty("Name").isReadOnly()).isTrue();
     assertThat(readOnly.getRequiredProperty("Age")).isSameAs(readOnly.Age).isNotSameAs(bean.Age).isEqualTo(bean.Age);
     assertThat(readOnly.getRequiredProperty("Age").isReadOnly()).isTrue();
-    String name = "John Doe";
-    bean.Name.set(name);
     assertThat(readOnly.Name.get()).isSameAs(name);
-    int age = 42;
-    bean.Age.set(age);
     assertThat(readOnly.Age.get()).isEqualTo(age);
-    assertThat(readOnly.getPropertyCount()).isEqualTo(2);
-    LocalDateProperty birthday = bean.addProperty(new LocalDateProperty("Birthday"));
-    assertThat(bean.getPropertyCount()).isEqualTo(3);
-    assertThat(bean.getProperty("Birthday")).isSameAs(birthday);
     assertThat(readOnly.getProperties()).hasSize(3);
     assertThat(readOnly.getPropertyCount()).isEqualTo(3);
     assertThat(readOnly.getProperty("Birthday")).isNotSameAs(birthday).isEqualTo(birthday);
     assertThat(readOnly.getProperty("Birthday").isReadOnly()).isTrue();
-    // yes, this is inconsistent and does not match the age, it is only a test
-    LocalDate date = LocalDate.of(2003, 02, 01);
-    birthday.set(date);
     assertThat(readOnly.getProperty("Birthday").get()).isSameAs(date);
-    StringProperty string = new StringProperty("String");
-    testAdvancedParentBeanClass.getPrototype().addProperty(string);
+    StringProperty string = testAdvancedParentBeanClass.getPrototype().addProperty(new StringProperty("String"));
+    string.set("defaultValue");
     assertThat(readOnly.getProperties()).hasSize(4);
     assertThat(readOnly.getProperty("String")).isEqualTo(string);
     bean.set("String", "value");
-    virtucalBeanClass.getPrototype().set("String", "defaultValue");
-    assertThat(readOnly.get("String")).isEqualTo("value");
-    bean = new TestAdvancedBean(true, virtucalBeanClass);
+    assertThat(bean.get("String")).isEqualTo("value");
+    assertThat(readOnly.get("String")).isEqualTo("defaultValue");
+    bean = new TestAdvancedBean(virtucalBeanClass);
     assertThat(bean.get("String")).isEqualTo("defaultValue");
   }
 

--- a/core/src/test/java/io/github/mmm/bean/DynamicBeanTest.java
+++ b/core/src/test/java/io/github/mmm/bean/DynamicBeanTest.java
@@ -25,7 +25,7 @@ public class DynamicBeanTest extends AbstractBeanTest {
     assertThat(bean.getPropertyCount()).isEqualTo(0);
     checkType(bean, "mmm.DynamicBean");
     assertThat(bean.getPropertyNameForAlias("Name")).isNull();
-    DynamicBean readOnly = WritableBean.getReadOnly(bean);
+    DynamicBean readOnly = ReadableBean.copy(bean, true);
     assertThat(readOnly.getPropertyNameForAlias("Name")).isNull();
 
     WritableProperty<String> nameProperty = bean.getOrCreateProperty("Name", String.class);

--- a/core/src/test/java/io/github/mmm/bean/examples/DynamicTestBean.java
+++ b/core/src/test/java/io/github/mmm/bean/examples/DynamicTestBean.java
@@ -1,0 +1,16 @@
+/* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0 */
+package io.github.mmm.bean.examples;
+
+/**
+ * {@link TestBean} that is {@link #isDynamic() dynamic}.
+ */
+public class DynamicTestBean extends TestBean {
+
+  @Override
+  public boolean isDynamic() {
+
+    return true;
+  }
+
+}

--- a/core/src/test/java/io/github/mmm/bean/examples/TestAdvancedBean.java
+++ b/core/src/test/java/io/github/mmm/bean/examples/TestAdvancedBean.java
@@ -2,7 +2,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0 */
 package io.github.mmm.bean.examples;
 
-import io.github.mmm.bean.AbstractBean;
 import io.github.mmm.bean.AdvancedBean;
 import io.github.mmm.bean.BeanClass;
 import io.github.mmm.bean.Name;
@@ -24,34 +23,13 @@ public class TestAdvancedBean extends TestAdvancedParentBean {
 
   public TestAdvancedBean() {
 
-    this(null, true, null);
+    this(null);
   }
 
-  public TestAdvancedBean(boolean dynamic) {
+  public TestAdvancedBean(BeanClass type) {
 
-    this(null, dynamic, null);
-  }
-
-  public TestAdvancedBean(AbstractBean writable, boolean dynamic) {
-
-    this(writable, dynamic, null);
-  }
-
-  public TestAdvancedBean(boolean dynamic, BeanClass type) {
-
-    this(null, dynamic, type);
-  }
-
-  public TestAdvancedBean(AbstractBean writable, boolean dynamic, BeanClass type) {
-
-    super(writable, dynamic, type);
-    this.Age = add(new IntegerProperty("Age"));
-  }
-
-  @Override
-  protected AbstractBean create(AbstractBean writableBean, boolean dynamicFlag) {
-
-    return new TestAdvancedBean(writableBean, dynamicFlag, getType());
+    super(type);
+    this.Age = add().newInteger("Age");
   }
 
 }

--- a/core/src/test/java/io/github/mmm/bean/examples/TestAdvancedParentBean.java
+++ b/core/src/test/java/io/github/mmm/bean/examples/TestAdvancedParentBean.java
@@ -2,7 +2,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0 */
 package io.github.mmm.bean.examples;
 
-import io.github.mmm.bean.AbstractBean;
 import io.github.mmm.bean.AdvancedBean;
 import io.github.mmm.bean.BeanClass;
 import io.github.mmm.bean.Name;
@@ -24,34 +23,19 @@ public class TestAdvancedParentBean extends AdvancedBean {
 
   public TestAdvancedParentBean() {
 
-    this(null, true, null);
+    this(null);
   }
 
-  public TestAdvancedParentBean(boolean dynamic) {
+  public TestAdvancedParentBean(BeanClass type) {
 
-    this(null, dynamic, null);
-  }
-
-  public TestAdvancedParentBean(AbstractBean writable, boolean dynamic) {
-
-    this(writable, dynamic, null);
-  }
-
-  public TestAdvancedParentBean(boolean dynamic, BeanClass type) {
-
-    this(null, dynamic, type);
-  }
-
-  public TestAdvancedParentBean(AbstractBean writable, boolean dynamic, BeanClass type) {
-
-    super(writable, dynamic, type);
+    super(type);
     this.Name = add(new StringProperty("Name"));
   }
 
   @Override
-  protected AbstractBean create(AbstractBean writableBean, boolean dynamicFlag) {
+  public boolean isDynamic() {
 
-    return new TestAdvancedParentBean(writableBean, dynamicFlag, getType());
+    return true;
   }
 
 }

--- a/core/src/test/java/io/github/mmm/bean/examples/TestBean.java
+++ b/core/src/test/java/io/github/mmm/bean/examples/TestBean.java
@@ -2,7 +2,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0 */
 package io.github.mmm.bean.examples;
 
-import io.github.mmm.bean.AbstractBean;
 import io.github.mmm.bean.Bean;
 import io.github.mmm.bean.Name;
 import io.github.mmm.property.number.integers.IntegerProperty;
@@ -25,37 +24,9 @@ public class TestBean extends Bean {
    */
   public TestBean() {
 
-    this(null, false);
-  }
-
-  /**
-   * The constructor.
-   * 
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public TestBean(boolean dynamic) {
-
-    this(null, dynamic);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public TestBean(AbstractBean writable, boolean dynamic) {
-
-    super(writable, dynamic);
-    this.Name = add(new StringProperty("Name"));
-    this.Age = add(new IntegerProperty("Age"));
-  }
-
-  @Override
-  protected AbstractBean create(AbstractBean writable, boolean dynamic) {
-
-    return new TestBean(writable, dynamic);
+    super();
+    this.Name = add().newString("Name");
+    this.Age = add().newInteger("Age");
   }
 
 }

--- a/core/src/test/java/io/github/mmm/bean/examples/TestBuildersBean.java
+++ b/core/src/test/java/io/github/mmm/bean/examples/TestBuildersBean.java
@@ -2,7 +2,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0 */
 package io.github.mmm.bean.examples;
 
-import io.github.mmm.bean.AbstractBean;
 import io.github.mmm.bean.Bean;
 import io.github.mmm.bean.Name;
 import io.github.mmm.property.container.list.ListProperty;
@@ -29,38 +28,16 @@ public class TestBuildersBean extends Bean {
    */
   public TestBuildersBean() {
 
-    this(null, false);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public TestBuildersBean(boolean dynamic) {
-
-    this(null, dynamic);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public TestBuildersBean(AbstractBean writable, boolean dynamic) {
-
-    super(writable, dynamic);
+    super();
     this.Name = add().newString().withValidator().mandatory().and().build("Name");
     this.Age = add().newInteger().withValidator().range(0, 150).and().build("Age");
     this.Hobbies = add().newString().withValidator().mandatory().pattern("[a-zA-Z ]").and().asList().build("Hobbies");
   }
 
   @Override
-  protected AbstractBean create(AbstractBean writable, boolean dynamic) {
+  public boolean isDynamic() {
 
-    return new TestBuildersBean(writable, dynamic);
+    return true;
   }
 
 }

--- a/factory/src/main/java/io/github/mmm/bean/factory/impl/SimpleBean.java
+++ b/factory/src/main/java/io/github/mmm/bean/factory/impl/SimpleBean.java
@@ -20,14 +20,11 @@ public final class SimpleBean extends AbstractBean {
   /**
    * The constructor.
    *
-   * @param writable the writable {@link SimpleBean} to create a {@link #isReadOnly() read-only} view on or {@code null}
-   *        to create a regular mutable {@link SimpleBean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
    * @param type the {@link #getType() type}.
    */
-  public SimpleBean(AbstractBean writable, boolean dynamic, BeanType type) {
+  public SimpleBean(BeanType type) {
 
-    super(writable, dynamic);
+    super();
     this.type = BeanTypeImpl.asType(getClass());
   }
 

--- a/factory/src/main/java/io/github/mmm/bean/factory/impl/SimpleVirtualBean.java
+++ b/factory/src/main/java/io/github/mmm/bean/factory/impl/SimpleVirtualBean.java
@@ -2,13 +2,13 @@
  * http://www.apache.org/licenses/LICENSE-2.0 */
 package io.github.mmm.bean.factory.impl;
 
-import io.github.mmm.bean.AbstractBean;
 import io.github.mmm.bean.AbstractVirtualBean;
-import io.github.mmm.bean.Bean;
 import io.github.mmm.bean.BeanClass;
+import io.github.mmm.bean.VirtualBean;
+import io.github.mmm.bean.factory.impl.proxy.BeanProxy;
 
 /**
- *
+ * Internal implementation of {@link VirtualBean} used from {@link BeanProxy}.
  */
 public final class SimpleVirtualBean extends AbstractVirtualBean {
 
@@ -23,26 +23,11 @@ public final class SimpleVirtualBean extends AbstractVirtualBean {
   /**
    * The constructor.
    *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public SimpleVirtualBean(AbstractBean writable, boolean dynamic) {
-
-    super(writable, dynamic);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
    * @param type the {@link #getType() type}.
    */
-  public SimpleVirtualBean(AbstractBean writable, boolean dynamic, BeanClass type) {
+  public SimpleVirtualBean(BeanClass type) {
 
-    super(writable, dynamic, type);
+    super(type);
   }
 
 }

--- a/factory/src/main/java/io/github/mmm/bean/factory/impl/proxy/BeanProxy.java
+++ b/factory/src/main/java/io/github/mmm/bean/factory/impl/proxy/BeanProxy.java
@@ -51,9 +51,9 @@ public abstract class BeanProxy implements InvocationHandler {
     this.beanFactory = beanFactory;
     this.dynamic = dynamic;
     if (beanType instanceof BeanClass) {
-      this.bean = new SimpleVirtualBean(writable, true, (BeanClass) beanType);
+      this.bean = new SimpleVirtualBean((BeanClass) beanType);
     } else {
-      this.bean = new SimpleBean(writable, true, beanType);
+      this.bean = new SimpleBean(beanType);
     }
   }
 

--- a/factory/src/test/java/io/github/mmm/bean/factory/test/TestBean.java
+++ b/factory/src/test/java/io/github/mmm/bean/factory/test/TestBean.java
@@ -13,7 +13,7 @@ import io.github.mmm.property.string.StringProperty;
  * A {@link Bean} for testing.
  */
 @Name("mmm.TestBean")
-public class TestBean extends AdvancedBean implements PersonBean {
+public final class TestBean extends AdvancedBean implements PersonBean {
 
   /** Full name of person. */
   public final StringProperty Name;
@@ -26,37 +26,15 @@ public class TestBean extends AdvancedBean implements PersonBean {
    */
   public TestBean() {
 
-    this(null, false);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public TestBean(boolean dynamic) {
-
-    this(null, dynamic);
-  }
-
-  /**
-   * The constructor.
-   *
-   * @param writable the writable {@link Bean} to create a {@link #isReadOnly() read-only} view on or {@code null} to
-   *        create a regular mutable {@link Bean}.
-   * @param dynamic the {@link #isDynamic() dynamic flag}.
-   */
-  public TestBean(AbstractBean writable, boolean dynamic) {
-
-    super(writable, dynamic);
+    super();
     this.Name = add().newString("Name");
     this.Age = add().newInteger().withValidator().range(0, 99).and().build("Age");
   }
 
   @Override
-  protected AbstractBean create(AbstractBean writable, boolean dynamic) {
+  protected AbstractBean create() {
 
-    return new TestBean(writable, dynamic);
+    return new TestBean();
   }
 
   @Override


### PR DESCRIPTION
For usage of the `Bean`s provided here, it is crutial that things are easy and do not require boiler-plate code. The previous approach with the read-only view support is quite nice but requires odd constructors to be added to every `Bean` class. With this PR we dramatically simplify this and remove the burden of custom constructors and only implement default contructor for regular `Bean`s.
To make things simpler we therefore remove the read-only view approach and replace it with the ability to create copies either read-only or writable according to a `boolean` argument.
We think that even though the read-only view approach was kind of nice, this simplification is still worth it.